### PR TITLE
Bump Consul version to 1.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM wehkamp/alpine:3.6
-LABEL container.name="wehkamp/consul:1.0.3"
+LABEL container.name="wehkamp/consul:1.0.6"
 
-ENV CONSUL_VERSION 1.0.3
+ENV CONSUL_VERSION 1.0.6
 
 RUN wget -q -O /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip \
     && cd /tmp \


### PR DESCRIPTION
1.0.3 -> 1.0.6, why not?