### PR TITLE
Telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM wehkamp/alpine:3.9-1
-LABEL container.name="wehkamp/consul:1.4.4"
+LABEL container.name="wehkamp/consul:1.4.4-2"
 
 ENV CONSUL_VERSION 1.4.4
 

--- a/config/consul.json
+++ b/config/consul.json
@@ -5,5 +5,9 @@
 		"dns": 8600
 	},
 	"recursors": ["10.200.16.2", "10.200.32.2", "10.200.0.2"],
-	"disable_update_check": true
+	"disable_update_check": true,
+    "telemetry": {
+        "disable_hostname": true,
+        "prometheus_retention_time": "120s"
+    }
 }

--- a/config/opkg.conf
+++ b/config/opkg.conf
@@ -1,5 +1,0 @@
-src/gz base http://downloads.openwrt.org/snapshots/trunk/x86/64/packages/base
-src/gz packages http://downloads.openwrt.org/snapshots/trunk/x86/64/packages/packages
-dest root /
-dest ram /tmp
-lists_dir ext /var/opkg-lists


### PR DESCRIPTION
Following [1] this will expose metrics on a non-standard path, so a config
change in prometheus will also be required. Having this in-place no
longer requires to use statsd, which exposes about the same information
but in a less pretty format.

[1] https://www.consul.io/docs/agent/options.html#telemetry-prometheus_retention_time